### PR TITLE
novos campos about e date no model Event

### DIFF
--- a/rolebackend/src/main/java/br/com/mytho/role/domain/model/Event.java
+++ b/rolebackend/src/main/java/br/com/mytho/role/domain/model/Event.java
@@ -1,9 +1,13 @@
 package br.com.mytho.role.domain.model;
 
+import java.util.Date;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 @Entity
 public class Event {
@@ -12,7 +16,18 @@ public class Event {
 	private Long id;
 	private String name;
 	private String imageLink;
+	private String about;
+	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm", timezone="UTC")
+	private Date date;
 	
+	public Date getDate() {
+		return date;
+	}
+
+	public void setDate(Date date) {
+		this.date = date;
+	}
+
 	public Long getId() {
 		return id;
 	}
@@ -31,6 +46,14 @@ public class Event {
 	
 	public String getName() {
 		return name;
+	}
+
+	public String getAbout() {
+		return about;
+	}
+
+	public void setAbout(String about) {
+		this.about = about;
 	}
 	
 }

--- a/rolebackend/src/main/java/br/com/mytho/role/domain/model/Event.java
+++ b/rolebackend/src/main/java/br/com/mytho/role/domain/model/Event.java
@@ -1,11 +1,13 @@
 package br.com.mytho.role.domain.model;
 
-import java.util.Date;
+import java.util.Calendar;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -18,13 +20,14 @@ public class Event {
 	private String imageLink;
 	private String about;
 	@JsonFormat(shape=JsonFormat.Shape.STRING, pattern="yyyy-MM-dd HH:mm", timezone="UTC")
-	private Date date;
+	@Temporal(TemporalType.TIMESTAMP)
+	private Calendar date;
 	
-	public Date getDate() {
+	public Calendar getDate() {
 		return date;
 	}
 
-	public void setDate(Date date) {
+	public void setDate(Calendar date) {
 		this.date = date;
 	}
 


### PR DESCRIPTION
Adicionei os campos que o Igor pediu de descrição (about) e data (date).
Usei Date ao invés de Calendar para facilitar a integração com o banco (datetime), dessa forma só foi necessário usar a notação @JsonFormat no atributo date.
